### PR TITLE
feat(jsonutils): add LoadAs and MarshalAs functions

### DIFF
--- a/pkg/jsonutils/jsonutils.go
+++ b/pkg/jsonutils/jsonutils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/sassoftware/sas-ggdk/pkg/result"
@@ -52,4 +53,18 @@ func UnmarshalFromReader(reader io.Reader, instance any) error {
 		return err
 	}
 	return nil
+}
+
+// LoadAs reads the content from the given path and ummarshals it into a result
+// of a new instance of T.
+func LoadAs[T any](path string) result.Result[T] {
+	content := result.New(os.ReadFile(path))
+	return result.FlatMap(UnmarshalAs[T], content)
+}
+
+// UnmarshalAs ummarshals the given content into a result of anew instance of T.
+func UnmarshalAs[T any](content []byte) result.Result[T] {
+	var t T
+	err := json.Unmarshal(content, &t)
+	return result.New(t, err)
 }

--- a/pkg/jsonutils/jsonutils_test.go
+++ b/pkg/jsonutils/jsonutils_test.go
@@ -108,6 +108,60 @@ func Test_UnmarshalFromReader_failingUnmarshal(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_LoadAs(t *testing.T) {
+	expected := person{
+		Name: "John Smith",
+		Age:  75,
+	}
+	actual := jsonutils.LoadAs[person](toTestdataFilename(jsonFilename))
+	require.False(t, actual.IsError())
+	require.Equal(t, expected, actual.MustGet())
+}
+
+func Test_LoadAs_ptr(t *testing.T) {
+	expectedPtr := &person{
+		Name: "John Smith",
+		Age:  75,
+	}
+	actualPtr := jsonutils.LoadAs[*person](toTestdataFilename(jsonFilename))
+	require.False(t, actualPtr.IsError())
+	require.Equal(t, expectedPtr, actualPtr.MustGet())
+}
+
+func Test_LoadAs_fail(t *testing.T) {
+	actual := jsonutils.LoadAs[person](toTestdataFilename("missing.json"))
+	require.True(t, actual.IsError())
+}
+
+func Test_UnmarshalAs(t *testing.T) {
+	expectedPtr := person{
+		Name: "John Smith",
+		Age:  75,
+	}
+	content, err := readTestdata(jsonFilename)
+	require.NoError(t, err)
+	actualPtr := jsonutils.UnmarshalAs[person](content)
+	require.False(t, actualPtr.IsError())
+	require.Equal(t, expectedPtr, actualPtr.MustGet())
+}
+
+func Test_UnmarshalAs_ptr(t *testing.T) {
+	expectedPtr := &person{
+		Name: "John Smith",
+		Age:  75,
+	}
+	content, err := readTestdata(jsonFilename)
+	require.NoError(t, err)
+	actualPtr := jsonutils.UnmarshalAs[*person](content)
+	require.False(t, actualPtr.IsError())
+	require.Equal(t, expectedPtr, actualPtr.MustGet())
+}
+
+func Test_UnmarshalAs_fail(t *testing.T) {
+	actual := jsonutils.UnmarshalAs[person]([]byte(`{"invalid": "json`))
+	require.True(t, actual.IsError())
+}
+
 func readTestdata(elements ...string) ([]byte, error) {
 	filename := toTestdataFilename(elements...)
 	path := filepath.Clean(filename)


### PR DESCRIPTION
This change adds the following functions to the jsonutils package. Unit tests are also provided.

`LoadAs[T any](path string) result.Result[T]` reads the content from the given path and ummarshals it into a result of a new instance of T.

`UnmarshalAs[T any](content []byt) reseult.Result[T] reads the content from the given path and ummarshals it into a result of a new instance of T.