### PR TITLE
feat(sliceutils): add ContainsAll and Duplicate functions

### DIFF
--- a/pkg/sliceutils/sliceutils.go
+++ b/pkg/sliceutils/sliceutils.go
@@ -89,6 +89,17 @@ func CollectErrors[T any](root error, elements ...result.Result[T]) error {
 	return nil
 }
 
+// ContainsAll returns true if the given target slice of values contains all the
+// given values, otherwise it returns false.
+func ContainsAll[T comparable](target []T, values []T) bool {
+	for _, value := range values {
+		if !slices.Contains(target, value) {
+			return false
+		}
+	}
+	return true
+}
+
 // Detect returns the first value found in the given slice of values that matches
 // the given filter. Returns a maybe.Nothing if no value is found. Returns a
 // result.Error if the filter fails.
@@ -178,6 +189,13 @@ func Disjoint[T comparable](left []T, right []T) result.Result[[]T] {
 		right,
 	)
 	return UniqueUnion(leftOnly.MustGet(), rightOnly.MustGet())
+}
+
+// Duplicate returns a newly allocated copy of the given slice.
+func Duplicate[T any](src []T) []T {
+	dst := make([]T, len(src))
+	_ = copy(dst, src)
+	return dst
 }
 
 // FirstError returns the first error, if any, in the given slice of

--- a/pkg/sliceutils/sliceutils_test.go
+++ b/pkg/sliceutils/sliceutils_test.go
@@ -93,6 +93,16 @@ func Test_CollectErrors_no_elements(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_ContainsAll(t *testing.T) {
+	haystack := []string{"one", "two", "three", "four", "five"}
+	presentNeedles := []string{"one", "three", "four"}
+	absentNeedles1 := []string{"one", "two", "three", "four", "five", "six"}
+	absentNeedles2 := []string{"one", "six"}
+	require.True(t, sliceutils.ContainsAll(haystack, presentNeedles))
+	require.False(t, sliceutils.ContainsAll(haystack, absentNeedles1))
+	require.False(t, sliceutils.ContainsAll(haystack, absentNeedles2))
+}
+
 func Test_Detect_error(t *testing.T) {
 	expectedMessage := `failed DETECT filter`
 	filter := newFailingFilter[string](expectedMessage)
@@ -281,6 +291,13 @@ func Test_Disjoint_empty(t *testing.T) {
 	actual := sliceutils.Disjoint(left, right)
 	require.NotNil(t, actual.MustGet())
 	require.Empty(t, actual.MustGet())
+}
+
+func Test_Duplicate(t *testing.T) {
+	src := []int{1, 2, 3}
+	dst := sliceutils.Duplicate(src)
+	require.Equal(t, src, dst)
+	require.NotSame(t, &src[0], &dst[0])
 }
 
 func Test_FirstError(t *testing.T) {


### PR DESCRIPTION
This change adds the following functions to the sliceutils package. Unit tests are also provided.

`ContainsAll[T comparable](target []T, values []T) bool` returns true if the given target slice of values contains all the given values, otherwise it returns false.

`Duplicate[T any](src []T) []T` returns a newly allocated copy of the given slice.