### PR TITLE
feat: add Close functions

### DIFF
--- a/pkg/maybe/maybe_test.go
+++ b/pkg/maybe/maybe_test.go
@@ -36,3 +36,59 @@ func Test_Just_Is_Just(t *testing.T) {
 	instance := maybe.Just(10)
 	require.True(t, maybe.IsJust(instance))
 }
+
+type named interface {
+	GetName() string
+}
+
+type instance struct{}
+
+func (i *instance) GetName() string { return "my name" }
+
+func Test_As(t *testing.T) {
+	m := maybe.Just(&instance{})
+	a := maybe.As[named](m)
+	require.True(t, a.IsJust())
+	require.Equal(t, "my name", a.MustGet().GetName())
+}
+
+func Test_As_NotSupported(t *testing.T) {
+	m := maybe.Just("string")
+	a := maybe.As[int](m)
+	require.False(t, a.IsJust())
+}
+
+func Test_As_FromNothing(t *testing.T) {
+	m := maybe.Nothing[string]()
+	a := maybe.As[int](m)
+	require.False(t, a.IsJust())
+}
+
+type closer struct {
+	called bool
+}
+
+func (c *closer) Close() error {
+	c.called = true
+	return nil
+}
+
+func Test_CloseCloser(t *testing.T) {
+	c := &closer{}
+	closerMaybe := maybe.Just(c)
+	err := maybe.Close(closerMaybe)
+	require.NoError(t, err)
+	require.True(t, c.called)
+}
+
+func Test_CloseNonCloser(t *testing.T) {
+	closerMaybe := maybe.Just(99)
+	err := maybe.Close(closerMaybe)
+	require.NoError(t, err)
+}
+
+func Test_CloseError(t *testing.T) {
+	closerMaybe := maybe.Nothing[int]()
+	err := maybe.Close(closerMaybe)
+	require.NoError(t, err)
+}

--- a/pkg/result/ok.go
+++ b/pkg/result/ok.go
@@ -3,7 +3,9 @@
 
 package result
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Ok returns a Result encapsulating the given value.
 func Ok[T any](value T) Result[T] {
@@ -45,6 +47,7 @@ func (o *ok[T]) get() T {
 	return o.value
 }
 
+// String returns a string representation of this Result.
 func (o *ok[T]) String() string {
 	return fmt.Sprintf("{Ok: %#v}", o.value)
 }

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -4,6 +4,8 @@
 package result
 
 import (
+	"io"
+
 	"github.com/sassoftware/sas-ggdk/pkg/errors"
 	"github.com/sassoftware/sas-ggdk/pkg/maybe"
 )
@@ -57,6 +59,21 @@ func As[T, S any](src Result[S]) Result[T] {
 		return Error[T](err)
 	}
 	return Ok(val)
+}
+
+// Close calls close on the encapsulated value if that value implements
+// io.Closer. It is a no-op if the value does not implement io.Closer or the
+// result encapsulates an error.
+func Close[T any](src Result[T]) error {
+	if src.IsError() {
+		return nil
+	}
+	v := any(src.MustGet())
+	closer, ok := v.(io.Closer)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
 }
 
 // ErrorMapper defines a function that takes an error and returns an error.

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -104,3 +104,32 @@ func Test_FromMaybe(t *testing.T) {
 	require.Error(t, rErr.Error())
 	require.ErrorContains(t, rErr.Error(), "failed")
 }
+
+type closer struct {
+	called bool
+}
+
+func (c *closer) Close() error {
+	c.called = true
+	return nil
+}
+
+func Test_CloseCloser(t *testing.T) {
+	c := &closer{}
+	closerResult := result.Ok(c)
+	err := result.Close(closerResult)
+	require.NoError(t, err)
+	require.True(t, c.called)
+}
+
+func Test_CloseNonCloser(t *testing.T) {
+	closerResult := result.Ok(99)
+	err := result.Close(closerResult)
+	require.NoError(t, err)
+}
+
+func Test_CloseError(t *testing.T) {
+	closerResult := result.Error[int](errors.New("failed"))
+	err := result.Close(closerResult)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This change adds a `Close` function to both the `maybe` and `result` packages. These funcitions call the Close method on their encapsulated values if there is a value and that value implements `io.Closer`. These are convience functions that could be implemented by users but are so common as to warrent inclusion.

An `As` function is also added to the `maybe` package to mirror the `result` package's `As` function.