### PR TITLE
feat: additional jsonutil features

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ make test-with-coverage
 
 This project currently uses loose [semantic versioning](https://semver.org/) and
 [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). The API
-is undergoing rapid evolution until 1.0 is released. Efforts will be made to
-communicate braking changes but please pin to a specific version until then.
+is undergoing rapid evolution until 1.0 is released. An evaluation will be made
+at that time as to how strictly semantic versioning will be followed. Efforts
+will be made to communicate breaking changes but please pin to a specific
+version until then.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ make test-with-coverage
 
 ### Commits
 
-This project uses [semantic versioning](https://semver.org/) and [conventional
-commits](https://www.conventionalcommits.org/en/v1.0.0/).
+This project currently uses loose [semantic versioning](https://semver.org/) and
+[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). The API
+is undergoing rapid evolution until 1.0 is released. Efforts will be made to
+communicate braking changes but please pin to a specific version until then.
 
 ## License
 

--- a/pkg/jsonutils/jsonutils.go
+++ b/pkg/jsonutils/jsonutils.go
@@ -8,63 +8,105 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/sassoftware/sas-ggdk/pkg/result"
 )
 
 // PrintJSONOn pretty-prints the given data as JSON on the given writer. If the
 // given data is not valid JSON an error is returned.
-func PrintJSONOn(data any, writer io.Writer) error {
-	bites, err := json.MarshalIndent(data, ``, `    `)
-	if err != nil {
+func PrintJSONOn[T any](data T, writer io.Writer) error {
+	bites := result.New(json.MarshalIndent(data, ``, `    `))
+	return result.MapErrorOnly(func(b []byte) error {
+		_, err := fmt.Fprintf(writer, "%s", b)
 		return err
-	}
-	content := string(bites)
-	_, err = fmt.Fprintf(writer, "%s\n", content)
-	return err
+	}, bites)
 }
 
 // ToJSON returns a pretty-printed JSON string for the given data. If the given
 // data is not valid JSON an error is returned. If you are marshaling a large
 // data structure and are concerned about the performance of iteratively growing
 // the destination strings.Builder then create your own builder, grow it to your
-// expected size, and then call PrintJSONOn.
-func ToJSON(data any) result.Result[string] {
-	writer := new(strings.Builder)
-	err := PrintJSONOn(data, writer)
-	if err != nil {
-		return result.Error[string](err)
-	}
-	content := writer.String()
-	return result.Ok(content)
+// expected size, and then call PrintJSONOn. If you want the bytes then call the
+// following.
+//
+//	result.New(json.MarshalIndent(data, ``, `    `))
+func ToJSON[T any](data T) result.Result[string] {
+	bites := result.New(json.MarshalIndent(data, ``, `    `))
+	return result.MapNoError(func(b []byte) string { return string(b) }, bites)
 }
 
-// UnmarshalFromReader inflates the JSON in the given reader and populates the
-// given instance. If the data in the reader is not valid JSON an error is
+// UnmarshalFromReader unmarshals the JSON in the given reader and populates a
+// new instance of T. If the data in the reader is not valid JSON an error is
 // returned.
-func UnmarshalFromReader(reader io.Reader, instance any) error {
-	bites, err := io.ReadAll(reader)
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal(bites, instance)
-	if err != nil {
-		return err
-	}
-	return nil
+func UnmarshalFromReader[T any](reader io.Reader) result.Result[T] {
+	bites := result.New(io.ReadAll(reader))
+	return result.FlatMap(UnmarshalAs[T], bites)
+}
+
+// UnmarshalAs ummarshals the given content into a result of a new instance of T.
+func UnmarshalAs[T any](content []byte) result.Result[T] {
+	var t T
+	err := json.Unmarshal(content, &t)
+	return result.New(t, err)
+}
+
+// UnmarshalFromReaderInto unmarshals the JSON in the given reader and populates
+// the given instance. If the data in the reader is not valid JSON an error is
+// returned.
+func UnmarshalFromReaderInto[T any](reader io.Reader, value *T) error {
+	bites := result.New(io.ReadAll(reader))
+	return result.MapErrorOnly(func(b []byte) error {
+		return json.Unmarshal(b, value)
+	}, bites)
 }
 
 // LoadAs reads the content from the given path and ummarshals it into a result
 // of a new instance of T.
 func LoadAs[T any](path string) result.Result[T] {
-	content := result.New(os.ReadFile(path))
+	return LoadWith[T](os.ReadFile, path)
+}
+
+// LoadWith passes the given path to the given read function to get the content.
+// That content is then marshaled into a result of a new instance of T. This is
+// useful when using a file system abstraction like
+// https://github.com/spf13/afero.
+//
+//	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+//	err := jsonutils.LoadWith[string](fs.ReadFile, "/tmp/person.json")
+func LoadWith[T any](
+	read func(string) ([]byte, error),
+	path string,
+) result.Result[T] {
+	content := result.New(read(path))
 	return result.FlatMap(UnmarshalAs[T], content)
 }
 
-// UnmarshalAs ummarshals the given content into a result of anew instance of T.
-func UnmarshalAs[T any](content []byte) result.Result[T] {
-	var t T
-	err := json.Unmarshal(content, &t)
-	return result.New(t, err)
+// Save marshals the given T and writes it to a file at the given path with the
+// given permissions. The file is truncated if it exists.
+func Save[T any](value T, path string, perm os.FileMode) error {
+	content := result.New(json.Marshal(value))
+	writeF := func(b []byte) error {
+		return os.WriteFile(path, b, perm)
+	}
+	return result.MapErrorOnly(writeF, content)
+}
+
+// SaveWith marshals the given T and calls the given writeFunc with the
+// resulting content, given path, and given permissions.This is
+// useful when using a file system abstraction like
+// https://github.com/spf13/afero.
+//
+//	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+//	err := jsonutils.SaveWith(fs.WriteFile, instance, "/tmp/person.json", 0700)
+func SaveWith[T any](
+	writeFunc func(string, []byte, os.FileMode) error,
+	value T,
+	path string,
+	perm os.FileMode,
+) error {
+	content := result.New(json.Marshal(value))
+	writeF := func(b []byte) error {
+		return writeFunc(path, b, perm)
+	}
+	return result.MapErrorOnly(writeF, content)
 }

--- a/pkg/jsonutils/jsonutils.go
+++ b/pkg/jsonutils/jsonutils.go
@@ -35,9 +35,9 @@ func ToJSON[T any](data T) result.Result[string] {
 	return result.MapNoError(func(b []byte) string { return string(b) }, bites)
 }
 
-// UnmarshalFromReader unmarshals the JSON in the given reader and populates a
-// new instance of T. If the data in the reader is not valid JSON an error is
-// returned.
+// UnmarshalFromReader unmarshals the JSON from the given reader and populates a
+// new instance of T. The reader will be read fully before returning. If the
+// data in the reader is not valid JSON an error is returned.
 func UnmarshalFromReader[T any](reader io.Reader) result.Result[T] {
 	bites := result.New(io.ReadAll(reader))
 	return result.FlatMap(UnmarshalAs[T], bites)
@@ -50,9 +50,9 @@ func UnmarshalAs[T any](content []byte) result.Result[T] {
 	return result.New(t, err)
 }
 
-// UnmarshalFromReaderInto unmarshals the JSON in the given reader and populates
-// the given instance. If the data in the reader is not valid JSON an error is
-// returned.
+// UnmarshalFromReaderInto unmarshals the JSON from the given reader and
+// populates the given instance. The reader will be read fully before returning.
+// If the data in the reader is not valid JSON an error is returned.
 func UnmarshalFromReaderInto[T any](reader io.Reader, value *T) error {
 	bites := result.New(io.ReadAll(reader))
 	return result.MapErrorOnly(func(b []byte) error {
@@ -84,11 +84,7 @@ func LoadWith[T any](
 // Save marshals the given T and writes it to a file at the given path with the
 // given permissions. The file is truncated if it exists.
 func Save[T any](value T, path string, perm os.FileMode) error {
-	content := result.New(json.Marshal(value))
-	writeF := func(b []byte) error {
-		return os.WriteFile(path, b, perm)
-	}
-	return result.MapErrorOnly(writeF, content)
+	return SaveWith(os.WriteFile, value, path, perm)
 }
 
 // SaveWith marshals the given T and calls the given writeFunc with the

--- a/pkg/jsonutils/jsonutils.go
+++ b/pkg/jsonutils/jsonutils.go
@@ -12,10 +12,15 @@ import (
 	"github.com/sassoftware/sas-ggdk/pkg/result"
 )
 
+const (
+	prefix = ``
+	indent = `    `
+)
+
 // PrintJSONOn pretty-prints the given data as JSON on the given writer. If the
 // given data is not valid JSON an error is returned.
 func PrintJSONOn[T any](data T, writer io.Writer) error {
-	bites := result.New(json.MarshalIndent(data, ``, `    `))
+	bites := result.New(json.MarshalIndent(data, prefix, indent))
 	return result.MapErrorOnly(func(b []byte) error {
 		_, err := fmt.Fprintf(writer, "%s", b)
 		return err
@@ -31,7 +36,7 @@ func PrintJSONOn[T any](data T, writer io.Writer) error {
 //
 //	result.New(json.MarshalIndent(data, ``, `    `))
 func ToJSON[T any](data T) result.Result[string] {
-	bites := result.New(json.MarshalIndent(data, ``, `    `))
+	bites := result.New(json.MarshalIndent(data, prefix, indent))
 	return result.MapNoError(func(b []byte) string { return string(b) }, bites)
 }
 


### PR DESCRIPTION
This change updates the jsonutil package to add functions related to saving and loading JSON content to and from disk.  It also adjusts the existing funcions to accomodate the new functions.

The following are added:

* `UnmarshalFromReaderInto`: This function provides functionality that was previously `UnmarshalFromReader`.
* `LoadAs`: This function reads the given path from the filesystem and unmarshals it into a new instance of the given type.
* `LoadWith`: This function calls the given read function and unmarshals the returned content into a new instance of the given type.
* `Save`: This function unmarshals the given instance and writes it to the specified path in the filesystem.
* `SaveWith`: this funcion unmarshals the given instance and passes the content, specified path, and specified mode to the specified write function.

The following have been updated:

* `PrintJSONOn`: This funtion no longer includes a trailing newline in content written to the provided io.Writer. It has been updated to take a type parameter.
* `ToJSON`: This function no longer includes a trainling newlint in the returned string. It has been updated to take a type parameter.
* `UnmarshalFromReader`: This function has been updated to return a new instance of the type being unmarshaled. The previous behavior of updating a instance allocated by the caller is now provided by `UnmarshalFromReaderInto`