### PR TITLE
feat(result): add split function

### DIFF
--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -45,6 +45,16 @@ func New[T any](value T, err error) Result[T] {
 	return Ok(value)
 }
 
+// Split splits a result into its value part and error part. If the Result
+// encapsulates an error then the zero value of T will be returned.
+func Split[T any](r Result[T]) (T, error) {
+	if r.IsError() {
+		var t T
+		return t, r.Error()
+	}
+	return r.MustGet(), nil
+}
+
 // As encapsulates the value in the given Result in a new Result of the target
 // type. If the given Result encapsulates an error then an Error Result will be
 // returned of the target type encapsulating the original error.

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sassoftware/sas-ggdk/pkg/errors"
 	"github.com/sassoftware/sas-ggdk/pkg/maybe"
+	"github.com/sassoftware/sas-ggdk/pkg/pointer"
 	"github.com/sassoftware/sas-ggdk/pkg/result"
 	"github.com/stretchr/testify/require"
 )
@@ -132,4 +133,33 @@ func Test_CloseError(t *testing.T) {
 	closerResult := result.Error[int](errors.New("failed"))
 	err := result.Close(closerResult)
 	require.NoError(t, err)
+}
+
+func Test_Split(t *testing.T) {
+	rI := result.Ok(1)
+	actualI, errI := result.Split(rI)
+	require.NoError(t, errI)
+	require.Equal(t, 1, actualI)
+	rI = result.Error[int](errors.New("failed int"))
+	actualI, errI = result.Split(rI)
+	require.EqualError(t, errI, "failed int")
+	require.Equal(t, 0, actualI)
+
+	rS := result.Ok("string")
+	actualS, errS := result.Split(rS)
+	require.NoError(t, errS)
+	require.Equal(t, "string", actualS)
+	rS = result.Error[string](errors.New("failed string"))
+	actualS, errS = result.Split(rS)
+	require.EqualError(t, errS, "failed string")
+	require.Empty(t, actualS)
+
+	rP := result.Ok(pointer.Ptr("pointer"))
+	actualP, errP := result.Split(rP)
+	require.NoError(t, errP)
+	require.Equal(t, "pointer", *actualP)
+	rP = result.Error[*string](errors.New("failed pointer"))
+	actualP, errP = result.Split(rP)
+	require.EqualError(t, errP, "failed pointer")
+	require.Equal(t, (*string)(nil), actualP)
 }


### PR DESCRIPTION
This change adds `result.Split` which takes a Result and returns the value and error parts as separate values.  If the Result encapsulates an error then the zero value of T is returned.